### PR TITLE
Add windows scripts

### DIFF
--- a/Software/waveview/package.json
+++ b/Software/waveview/package.json
@@ -36,8 +36,7 @@
     "electron-pack": "electron-builder -lmw",
     "postinstall": "electron-builder install-app-deps",
     "electron-dev": "concurrently \"BROWSER=none npm run start\" \"wait-on http://localhost:3000 && ./node_modules/.bin/tsc -p electron -w\" \"wait-on http://localhost:3000 && ./node_modules/.bin/tsc -p electron && electron .\"",
-    "electron-no-browser-win": "set \"BROWSER=none\" && call npm run start",
-    "electron-dev-win": "concurrently \"npm run electron-no-browser-win\" \"wait-on http://localhost:3000 && node_modules\\.bin\\tsc -p electron -w\" \"wait-on http://localhost:3000 && node_modules\\.bin\\tsc -p electron && electron %INIT_CWD%\"",
+    "electron-dev-win": "concurrently \"set BROWSER=none && call npm run start\" \"wait-on http://localhost:3000 && node_modules\\.bin\\tsc -p electron -w\" \"wait-on http://localhost:3000 && node_modules\\.bin\\tsc -p electron && electron %INIT_CWD%\"",
     "electron-build": "npm run build && ./node_modules/.bin/tsc -p electron && electron-builder",
     "electron-build-win": "npm run build && node_modules\\.bin\\tsc -p electron && electron-builder"
   },


### PR DESCRIPTION
An incredible branch for an incredible command line. And by 'incredible', I mean stupid.

These scripts should work in the Command Prompt and in Powershell, assuming you're using normal Windows npm in a normal Windows folder and not inside a weird filesystem (ie it probably won't work inside the WSL home directory).

NPM packages such as "concurrently" can work inside npm commands even if they don't work inside Command Prompt or Powershell. Don't ask me how...