### PR TITLE
Ensured that the RX and TX threads do not block so threads can always…

### DIFF
--- a/Software/waveview/scope_link/include/bridge.hpp
+++ b/Software/waveview/scope_link/include/bridge.hpp
@@ -23,6 +23,9 @@
 #endif
 
 #define BRIDGE_BUFFER_SIZE 4096
+#define END_PACKET_COMMAND 0xEF
+#define END_PACKET_PACKETID 0xAB
+#define END_PACKET_DATA_SIZE 0x00
 
 // PACKET STRUCTURE
 //   _______________________________________________________________________________________________________


### PR DESCRIPTION
… be stopped

Did this by adding code to have the program try to connect to the pipe for both TX and RX so they do not block on accepting clients, and on the RX pipe, have the program send it an END_CONNECTION packet header