### PR TITLE
better logging with TRACE, DEBUG, and FATAL

### DIFF
--- a/Software/waveview/scope_link/include/logger.hpp
+++ b/Software/waveview/scope_link/include/logger.hpp
@@ -29,4 +29,6 @@ typedef boost::log::sources::severity_logger_mt<boost::log::trivial::severity_le
 //declares a global logger with a custom initialization
 BOOST_LOG_GLOBAL_LOGGER(my_logger, logger_t)
 
+std::string convert_int(int n);
+
 #endif // logger_h

--- a/Software/waveview/scope_link/src/EVTester.cpp
+++ b/Software/waveview/scope_link/src/EVTester.cpp
@@ -52,7 +52,7 @@ bool loadFromFile ( char* filename, boost::lockfree::queue<buffer*, boost::lockf
 
             tmpBufPos++;
             if (tmpBufPos == BUFFER_SIZE) {
-                INFO << "Adding buffer to queue from file";
+                DEBUG << "Adding buffer to queue from file";
                 // Buffer is now full push it
                 outputQ->push(tempBuffer);
 

--- a/Software/waveview/scope_link/src/controller.cpp
+++ b/Software/waveview/scope_link/src/controller.cpp
@@ -37,7 +37,7 @@ controller::~controller()
     delete postProcessorThread;
     delete bridgeThread;
 
-    INFO << "Controller Destroyed";
+    DEBUG << "Controller Destroyed";
 }
 
 /*******************************************************************************
@@ -58,15 +58,15 @@ void controller::controllerLoop()
     while (stopController.load() == false) {
         while (stopController.load() == false &&
                controllerQueue_rx.pop(currentPacket)) {
-            INFO << "Controller processing a packet";
+            DEBUG << "Controller processing a packet";
 
             // execute the packet command
             switch (currentPacket->command) {
                 case 1:
-                    INFO << "Packet command 1";
+                    DEBUG << "Packet command 1";
                     break;
                 case 2:
-                    INFO << "Packet command 2";
+                    DEBUG << "Packet command 2";
                     break;
                 default:
                     ERROR << "Unknown packet command";
@@ -92,7 +92,7 @@ void controller::controllerLoop()
  ******************************************************************************/
 void controller::controllerPause()
 {
-    INFO << "Pausing pipeline";
+    DEBUG << "Pausing pipeline";
     processorThread->processorPause();
     triggerThread->triggerPause();
     postProcessorThread->postProcessorPause();
@@ -111,7 +111,7 @@ void controller::controllerPause()
  ******************************************************************************/
 void controller::controllerUnPause()
 {
-    INFO << "Unpausing pipeline";
+    DEBUG << "Unpausing pipeline";
     processorThread->processorUnpause();
     triggerThread->triggerUnpause();
     postProcessorThread->postProcessorUnpause();
@@ -152,19 +152,19 @@ void controller::controllerFlush()
     // Clear queues
     size_t count = 0;
     count = (*dataQueue).consume_all(bufferFunctor);
-    INFO << "Flushed inputQueue: " << count;
+    DEBUG << "Flushed inputQueue: " << count;
 
     count = triggerProcessorQueue.consume_all(bufferFunctor);
-    INFO << "Flushed triggeredQueue: " << count;
+    DEBUG << "Flushed triggeredQueue: " << count;
 
     // Clear persistence buffer
     processorThread->flushPersistence();
-    INFO << "Flushed persistence buffer";
+    DEBUG << "Flushed persistence buffer";
 //    count = preProcessorQueue.consume_all(bufferFunctor);
-//    INFO << "Flushed preProcessorQueue: " << count;
+//    DEBUG << "Flushed preProcessorQueue: " << count;
 
     count = processorPostProcessorQueue_1.consume_all(free);
-    INFO << "Flushed postProcessorQueue: " << count;
+    DEBUG << "Flushed postProcessorQueue: " << count;
 }
 
 /*******************************************************************************

--- a/Software/waveview/scope_link/src/logger.cpp
+++ b/Software/waveview/scope_link/src/logger.cpp
@@ -45,3 +45,23 @@ BOOST_LOG_GLOBAL_LOGGER_INIT(my_logger, logger_t)
 
     return lg;
 }
+
+/*******************************************************************************
+ * convert_int()
+ *
+ * converts an integer to a hex string.
+ *
+ * Arguments:
+ *   int n - integer to convert.
+ *
+ * Return:
+ *   string - integer n as an uppercase string.
+ ******************************************************************************/
+std::string convert_int(int n)
+{
+    std::stringstream ss;
+    ss << std::uppercase << std::hex;
+    ss << n;
+    return ss.str();
+}
+

--- a/Software/waveview/scope_link/src/main.cpp
+++ b/Software/waveview/scope_link/src/main.cpp
@@ -184,8 +184,7 @@ void runCli() {
 
     bool parseThings = true;
     while(parseThings) {
-        INFO << "Input a command";
-        printf("> ");
+        INFO << "Input a command\n>";
         std::string line;
         std::getline(std::cin, line);
 

--- a/Software/waveview/scope_link/src/postProcessor.cpp
+++ b/Software/waveview/scope_link/src/postProcessor.cpp
@@ -53,7 +53,7 @@ postProcessor::~postProcessor(void)
     postProcessorStop();
     postProcessorThread.join();
 
-    INFO << "Destroyed post processor";
+    DEBUG << "Destroyed post processor";
 }
 
 /*******************************************************************************
@@ -80,7 +80,7 @@ void postProcessor::coreLoop()
         while (pauseTransfer.load() == false &&
                inputQueue->pop(currentWindow)) {
 
-            INFO << "post processing next window";
+            DEBUG << "post processing next window";
 
             // TODO: Could do each channel in parrallel
             for (uint8_t j = 0; j < numCh; j++) {
@@ -89,12 +89,12 @@ void postProcessor::coreLoop()
 
                 // Post process window
                 // TODO: Add interpolation here.
-                std::cout << "Post Processed window";
+                std::string dbgMsg = "Post Processed window ";
                 for (uint32_t i = 0; i < windowSize; i++) {
                     postWindow[i] = currentWindow[i * numCh + j];
-                    std::cout << " " << (int)currentWindow[i * numCh + j];
+                    dbgMsg += std::to_string(currentWindow[i * numCh + j]) + " ";
                 }
-                std::cout << std::endl;
+                DEBUG << dbgMsg;
 
                 // Pass processed window to next stage
                 currentPacket = (EVPacket*)malloc(sizeof(EVPacket));
@@ -143,7 +143,7 @@ void postProcessor::setCh (int8_t newCh)
 void postProcessor::postProcessorStart()
 {
     stopTransfer.store(false);
-    INFO << "Starting post processing";
+    DEBUG << "Starting post processing";
 }
 
 /*******************************************************************************
@@ -160,7 +160,7 @@ void postProcessor::postProcessorStart()
 void postProcessor::postProcessorStop()
 {
     stopTransfer.store(true);
-    INFO << "Stopping post processing";
+    DEBUG << "Stopping post processing";
 }
 
 /*******************************************************************************
@@ -177,7 +177,7 @@ void postProcessor::postProcessorStop()
 void postProcessor::postProcessorUnpause()
 {
     pauseTransfer.store(false);
-    INFO << "unpausing post processing";
+    DEBUG << "unpausing post processing";
 }
 
 /*******************************************************************************
@@ -194,5 +194,5 @@ void postProcessor::postProcessorUnpause()
 void postProcessor::postProcessorPause()
 {
     pauseTransfer.store(true);
-    INFO << "pausing post processing";
+    DEBUG << "pausing post processing";
 }

--- a/Software/waveview/scope_link/src/trigger.cpp
+++ b/Software/waveview/scope_link/src/trigger.cpp
@@ -1,5 +1,4 @@
 #include "trigger.hpp"
-#define DBG
 
 Trigger::Trigger(boost::lockfree::queue<buffer*, boost::lockfree::fixed_sized<false>> *inputQ,
                  boost::lockfree::queue<buffer*, boost::lockfree::fixed_sized<false>> *outputQ,
@@ -36,14 +35,14 @@ Trigger::Trigger(boost::lockfree::queue<buffer*, boost::lockfree::fixed_sized<fa
 
 Trigger::~Trigger(void)
 {
-    INFO << "Trigger Destructor Called";
+    DEBUG << "Trigger Destructor Called";
 
     // Stop the transer and join thread
     stopTrigger.store(true);
     pauseTrigger.store(true);
     triggerThread.join();
 
-    INFO << "Destroyed Trigger Thread";
+    DEBUG << "Destroyed Trigger Thread";
 }
 
 #ifdef DBG
@@ -52,9 +51,7 @@ uint32_t temp = 0;
 
 void Trigger::checkTriggerFalling(buffer* currentBuffer)
 {
-#ifdef DBG
-    INFO << "Checking a Trigger with #ch: " << (int)numCh << " triggering on ch: " << (int)triggerCh;
-#endif
+    DEBUG << "Checking a Trigger with #ch: " << (int)numCh << " triggering on ch: " << (int)triggerCh;
     // Compute the trigger
     for (int i = 0; i < (BUFFER_SIZE/64)/numCh; i++) {
         currentBuffer->trigger[i] = 
@@ -189,7 +186,7 @@ void Trigger::checkTriggerFalling(buffer* currentBuffer)
 
 #ifdef DBG
         if (temp < 32) {
-            INFO << "Trigger index: " << i << " value: " << std::hex << currentBuffer->trigger[i];
+            DEBUG << "Trigger index: " << i << " value: " << std::hex << currentBuffer->trigger[i];
             temp++;
         }
 #endif
@@ -198,9 +195,7 @@ void Trigger::checkTriggerFalling(buffer* currentBuffer)
 
 void Trigger::checkTriggerRising(buffer* currentBuffer)
 {
-#ifdef DBG
-    INFO << "Checking a Trigger with #ch: " << (int)numCh << " triggering on ch: " << (int)triggerCh;
-#endif
+    DEBUG << "Checking a Trigger with #ch: " << (int)numCh << " triggering on ch: " << (int)triggerCh;
     // Compute the trigger
     for (int i = 0; i < (BUFFER_SIZE/64)/numCh; i++) {
         currentBuffer->trigger[i] = 
@@ -335,7 +330,7 @@ void Trigger::checkTriggerRising(buffer* currentBuffer)
 
 #ifdef DBG
         if (temp < 32) {
-            INFO << "Trigger index: " << i << " value: " << std::hex << currentBuffer->trigger[i];
+            DEBUG << "Trigger index: " << i << " value: " << std::hex << currentBuffer->trigger[i];
             temp++;
         }
 #endif
@@ -352,10 +347,10 @@ void Trigger::coreLoop()
         ERROR << "Input Queue null in trigger core loop";
     } else {
         while (inputQueue->pop(currentBuffer) == false && stopTrigger.load() == false) {
-//            INFO << "Waiting for first data element";
+//            DEBUG << "Waiting for first data element";
             std::this_thread::sleep_for(std::chrono::microseconds(100));
         };
-        INFO << "Core Loop Entered";
+        DEBUG << "Core Loop Entered";
 
         // Outer loop
         while (stopTrigger.load() == false) {
@@ -367,7 +362,7 @@ void Trigger::coreLoop()
                 if (inputQueue->pop(nextBuffer)) {
                     count++;
 
-                    INFO << "trigger next buffer";
+                    DEBUG << "trigger next buffer";
 
                     // copy first value from next buffer to current buffer
                     currentBuffer->data[BUFFER_SIZE] = nextBuffer->data[0];
@@ -422,14 +417,14 @@ void Trigger::setRising()
 {
     triggerPause();
     risingEdge = true;
-    INFO << "Triggering on rising edge";
+    DEBUG << "Triggering on rising edge";
 }
 
 void Trigger::setFalling()
 {
     triggerPause();
     risingEdge = false;
-    INFO << "Triggering on falling edge";
+    DEBUG << "Triggering on falling edge";
 }
 
 bool Trigger::getTriggerStatus()
@@ -440,25 +435,25 @@ bool Trigger::getTriggerStatus()
 void Trigger::triggerStop()
 {
     stopTrigger.store(true);
-    INFO << "Stopping Trigger";
+    DEBUG << "Stopping Trigger";
 }
 
 void Trigger::triggerStart()
 {
     stopTrigger.store(false);
-    INFO << "Starting Trigger";
+    DEBUG << "Starting Trigger";
 }
 
 void Trigger::triggerPause()
 {
     pauseTrigger.store(true);
-    INFO << "Pausing Trigger";
+    DEBUG << "Pausing Trigger";
 }
 
 void Trigger::triggerUnpause()
 {
     pauseTrigger.store(false);
-    INFO << "Unpausing Trigger";
+    DEBUG << "Unpausing Trigger";
 }
 
 uint32_t Trigger::getCount()


### PR DESCRIPTION
Added 3 new logging levels: TRACE, DEBUG, and FATAL
Log level can be changed in logger.hpp:42 by just changing the log severity to the desired level. doing so will not print anything with a lower severity level. IE setting it to "info" will not print any DEBUG or TRACE logs but will print INFO, ERROR, WARN and FATAL logs
Also moved a lot of things from INFO to DEBUG

printing an array can be done by doing string concatenation. for an example of it, look at the PrintPacket() function.
Also added a helper function to convert a integer to a hex string: convert_int() in logger.cpp